### PR TITLE
::pencil: impl pci hot reset interface in vfio-ioctl [#8]

### DIFF
--- a/crates/vfio-bindings/src/bindings_v5_0_0/vfio.rs
+++ b/crates/vfio-bindings/src/bindings_v5_0_0/vfio.rs
@@ -2258,28 +2258,3 @@ fn bindgen_test_layout_vfio_iommu_spapr_tce_remove() {
         )
     );
 }
-
-const DEV_NUM_MAX: usize = 64;
-#[repr(C)]
-#[derive(Debug)]
-pub struct vfio_pci_hot_reset_infos {
-    pub argsz: __u32,
-    pub flags: __u32,
-    pub count: __u32,
-    pub devices: [vfio_pci_dependent_device; DEV_NUM_MAX],
-}
-
-impl Default for vfio_pci_hot_reset_infos {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct vfio_pci_hot_resets {
-    pub argsz: __u32,
-    pub flags: __u32,
-    pub count: __u32,
-    pub fd: i32,
-}

--- a/crates/vfio-bindings/src/bindings_v5_0_0/vfio.rs
+++ b/crates/vfio-bindings/src/bindings_v5_0_0/vfio.rs
@@ -2258,3 +2258,28 @@ fn bindgen_test_layout_vfio_iommu_spapr_tce_remove() {
         )
     );
 }
+
+const DEV_NUM_MAX: usize = 64;
+#[repr(C)]
+#[derive(Debug)]
+pub struct vfio_pci_hot_reset_infos {
+    pub argsz: __u32,
+    pub flags: __u32,
+    pub count: __u32,
+    pub devices: [vfio_pci_dependent_device; DEV_NUM_MAX],
+}
+
+impl Default for vfio_pci_hot_reset_infos {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct vfio_pci_hot_resets {
+    pub argsz: __u32,
+    pub flags: __u32,
+    pub count: __u32,
+    pub fd: i32,
+}

--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -15,7 +15,6 @@ features = ["kvm"]
 [features]
 default = ["kvm"]
 noiommu = []
-vftoken = ["uuid"]
 kvm = ["kvm-ioctls", "kvm-bindings"]
 mshv = ["mshv-ioctls", "mshv-bindings"]
 
@@ -23,11 +22,10 @@ mshv = ["mshv-ioctls", "mshv-bindings"]
 byteorder = ">=1.2.1"
 libc = ">=0.2.39"
 log = "0.4"
-uuid = { version = ">=0.8.2", optional = true }
 kvm-bindings = { version = "~0", optional = true }
 kvm-ioctls = { version = "~0", optional = true }
 thiserror = ">=1.0"
-vfio-bindings = "~0"
+vfio-bindings = { path = "../vfio-bindings" }
 vm-memory = { version = ">=0.6", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.8.0"
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }

--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -25,7 +25,8 @@ log = "0.4"
 kvm-bindings = { version = "~0", optional = true }
 kvm-ioctls = { version = "~0", optional = true }
 thiserror = ">=1.0"
-vfio-bindings = { path = "../vfio-bindings" }
+vfio-bindings = "~0"
+##vfio-bindings = { path = "../vfio-bindings" }
 vm-memory = { version = ">=0.6", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.8.0"
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -777,8 +777,10 @@ impl VfioDevice {
     }
 
     /// VFIO pci hot reset only if the device supports being reset.
-    pub fn pci_hot_reset(&self) {
-        if self.flags & VFIO_DEVICE_FLAGS_RESET != 0 && vfio_syscall::pci_hot_reset(self) < 0 {
+    pub fn pci_hot_reset(&self, devnum: usize) {
+        if self.flags & VFIO_DEVICE_FLAGS_RESET != 0
+            && vfio_syscall::pci_hot_reset(self, devnum) < 0
+        {
             let err = std::io::Error::last_os_error();
             error!("vfio pci hot reset failed. err={}", err);
         }
@@ -1268,7 +1270,7 @@ mod tests {
         assert_eq!(device.regions.len(), 7);
         assert_eq!(device.irqs.len(), 3);
 
-        device.pci_hot_reset();
+        device.pci_hot_reset(64);
 
         assert!(device.get_irq_info(3).is_none());
         let irq = device.get_irq_info(2).unwrap();

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -422,20 +422,10 @@ impl VfioGroup {
         self.id
     }
 
-    fn get_device(
-        &self,
-        name: &Path,
-        #[cfg(feature = "vftoken")] vf_token: &uuid::Uuid,
-    ) -> Result<VfioDeviceInfo> {
+    fn get_device(&self, name: &Path) -> Result<VfioDeviceInfo> {
         let uuid_osstr = name.file_name().ok_or(VfioError::InvalidPath)?;
         let uuid_str = uuid_osstr.to_str().ok_or(VfioError::InvalidPath)?;
-        #[cfg(not(feature = "vftoken"))]
-        let path = CString::new(uuid_str.as_bytes()).expect("CString::new() failed");
-        #[cfg(feature = "vftoken")]
-        let path = {
-            let dev_path = format!("{} vf_token={}", uuid_str, vf_token);
-            CString::new(dev_path.as_bytes()).expect("CString::new() failed")
-        };
+        let path: CString = CString::new(uuid_str.as_bytes()).expect("CString::new() failed");
         let device = vfio_syscall::get_group_device_fd(self, &path)?;
 
         let mut dev_info = vfio_device_info {
@@ -762,17 +752,10 @@ impl VfioDevice {
     /// # Parameters
     /// * `sysfspath`: specify the vfio device path in sys file system.
     /// * `container`: the new VFIO device object will bind to this container object.
-    pub fn new(
-        sysfspath: &Path,
-        container: Arc<VfioContainer>,
-        #[cfg(feature = "vftoken")] vf_token: &uuid::Uuid,
-    ) -> Result<Self> {
+    pub fn new(sysfspath: &Path, container: Arc<VfioContainer>) -> Result<Self> {
         let group_id = Self::get_group_id_from_path(sysfspath)?;
         let group = container.get_group(group_id)?;
-        #[cfg(not(feature = "vftoken"))]
         let device_info = group.get_device(sysfspath)?;
-        #[cfg(feature = "vftoken")]
-        let device_info = group.get_device(sysfspath, vf_token)?;
         let regions = device_info.get_regions()?;
         let irqs = device_info.get_irqs()?;
 
@@ -795,7 +778,7 @@ impl VfioDevice {
 
     /// VFIO pci hot reset only if the device supports being reset.
     pub fn pci_hot_reset(&self) {
-        if vfio_syscall::pci_hot_reset(self) != 0 {
+        if self.flags & VFIO_DEVICE_FLAGS_RESET != 0 && vfio_syscall::pci_hot_reset(self) < 0 {
             let err = std::io::Error::last_os_error();
             error!("vfio pci hot reset failed. err={}", err);
         }


### PR DESCRIPTION
  according to https://github.com/VILLASframework/VILLAScommon/blob/9d1ae369211071decdcfdbfc9496e301049e3c97/lib/kernel/vfio.cpp#L539-L603
  port c to rust